### PR TITLE
Add basics for narration and update PhaseType enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "colyseus": "^0.14.20",
     "cors": "^2.8.5",
     "express": "^4.16.4",
-    "serve-index": "^1.9.1"
+    "serve-index": "^1.9.1",
+    "seed-random": "^2.2.0"
   }
 }

--- a/src/Narrator.ts
+++ b/src/Narrator.ts
@@ -1,0 +1,49 @@
+import seedRandom from "seed-random";
+
+const themes = [
+    "Mafia",
+    "Cultists",
+    "Fanatics",
+    "Zealots",
+    "Werewolves",
+    "Vampires"
+]
+
+const settings: [string, string][] = [
+    ["Prohibition-era", "town"],
+    ["Frontier", "town"],
+    ["Medieval", "village"],
+    ["Modern", "town"],
+]
+
+export class Narrator {
+    seed: string;
+    theme: string;
+    setting: [string, string];
+
+    /*
+     * This is called when we call "new Narrator()"
+     * It seeds Math.random() so that we get the same random numbers in the same
+     * order each time we run the game. This is important while developing so we
+     * can validate the results of the narrator. When we actually release the
+     * game we will uncomment out the seed line and generate a random seed.
+    */
+    constructor() {
+        this.seed = "clay is great";//String(Math.floor(Math.random() * 100000));
+        seedRandom(this.seed, { global: true });
+    }
+
+   /*
+    * Initializes the theme and setting for the narration and returns an
+    * introduction to the theme and setting
+    */
+   public getTheme(): string {
+        this.theme = themes[Math.floor(Math.random()*themes.length)];
+        console.log("Theme is: ", this.theme);
+        this.setting = settings[Math.floor(Math.random()*settings.length)];
+        console.log("Setting is: ", this.setting);
+        return "You find yourself in a " + this.setting[0] + " " + this.setting[1] +
+               " that has secretly become infested with " + this.theme + ". " +
+               "You will need to do everything you can to survive.";
+    }
+}

--- a/src/rooms/schema/MyRoomState.ts
+++ b/src/rooms/schema/MyRoomState.ts
@@ -1,4 +1,5 @@
 import { Schema, type, MapSchema } from "@colyseus/schema";
+import { PhaseType } from "../MyRoom";
 
 export class Player extends Schema {
   @type("string") name: string;
@@ -8,22 +9,17 @@ export class Player extends Schema {
 
 export class State extends Schema {
   @type("number") countdown: number;
-  @type("string") phase = "LOBBY";
-  @type("number") phaseIndex = 0;
-  @type(["string"]) phaseArr = [
-    "LOBBY",
-    "INTRODUCTION",
-    "NIGHT",
-    "NARRATIONMORNING",
-    "VOTING",
-    "NARRATIONLYNCHING",
-    "CONCLUSION",
-  ];
+  @type("number") phase = PhaseType.LOBBY;
+  @type("string") narration = "Welcome to Mafia";
 
   nextPhase() {
-    this.phaseIndex = this.phaseArr.indexOf(this.phase);
-    if (this.phaseIndex >= 0 && this.phaseIndex < this.phaseArr.length - 1)
-      this.phase = this.phaseArr[this.phaseIndex + 1];
+    if (this.phase >= PhaseType.LOBBY && this.phase < PhaseType.CONCLUSION - 1) {
+      this.phase = this.phase + 1;
+    }
+  }
+
+  setNarration(narration: string) {
+    this.narration = narration;
   }
 
   @type({ map: Player })


### PR DESCRIPTION
This is the beginning of my work on the Narrator. While puzzling out how I wanted it to work, I ended up updating the PhaseType enum to use numbers instead of strings. This allows us to simplify the phase logic and only pass a single number around.