### PR TITLE
Implement voting messages in the backend

### DIFF
--- a/src/rooms/Phase.ts
+++ b/src/rooms/Phase.ts
@@ -77,15 +77,26 @@ export function roomOwnerConfirms(players: MapSchema<Player>): boolean {
   return confirmed;
 }
 
-// Checks every Player, if all Players confirm, then returns true.
+// Checks every Player, if all living Players confirm, then returns true.
 export function allConfirmed(players: MapSchema<Player>): boolean {
   let confirmed = true;
 
   players.forEach((player, id) => {
-    confirmed &&= player.confirmed;
+    confirmed &&= player.confirmed || !player.alive;
   });
 
   return confirmed;
+}
+
+// Checks every Player, if all living Players confirm, then returns true.
+export function allVoted(players: MapSchema<Player>): boolean {
+  let voted = true;
+
+  players.forEach((player, id) => {
+    voted &&= player.voted || !player.alive;
+  });
+
+  return voted;
 }
 
 function anyTownspersonAlive(players: MapSchema<Player>): boolean {

--- a/src/rooms/schema/MyRoomState.ts
+++ b/src/rooms/schema/MyRoomState.ts
@@ -12,6 +12,7 @@ export class Player extends Schema {
   @type("number") role: Role;
   @type("boolean") room_owner = false;
   @type("boolean") confirmed = false;
+  @type("boolean") voted = false;
 }
 
 export class State extends Schema {


### PR DESCRIPTION
I implemented two voting messages:
``"voteForLynch"``: send this message once a player casts a vote along with the ``sessionId`` of the person they are voting for. Once the last player votes, this will automatically tally votes and kill the correct player. In case of a tie, the person checked first is killed. Eventually we may want to update that logic to kill no one. 
``"votForWhack"``: send this message when the mafia decides on who they kill. It just kills the player as we have no angel for now

Now that players can die, it is important to check the ``player.alive`` boolean when looping over players. 

Finally, I added a ``voted`` field to the player state so we can properly keep track of when all votes have been cast. this will be useful to add on the front end as well so you can display a "waiting for X player" message. 