### PR TITLE
Add ability to have multiple mafia

### DIFF
--- a/src/rooms/Phase.ts
+++ b/src/rooms/Phase.ts
@@ -98,6 +98,17 @@ export function allVoted(players: MapSchema<Player>): boolean {
   return voted;
 }
 
+// Checks every Player, if all living Mafia voted, then returns true.
+export function allMafiaVoted(players: MapSchema<Player>): boolean {
+  let voted = true;
+
+  players.forEach((player, id) => {
+    voted &&= (player.voted || !player.alive) && player.role === Role.MAFIA;
+  });
+
+  return voted;
+}
+
 function anyTownspersonAlive(players: MapSchema<Player>): boolean {
   let any_townsperson = false;
 

--- a/src/rooms/schema/MyRoomState.ts
+++ b/src/rooms/schema/MyRoomState.ts
@@ -44,13 +44,7 @@ export class State extends Schema {
     this.players.delete(sessionId);
   }
 
-  assignRoles() {
-    // Fill an array based on what roles are available.
-    // For now this is 1 mafia and the rest are townspeople.
-    let roles: Array<Role> = Array<Role>(this.players.size);
-    roles[0] = Role.MAFIA;
-    roles.fill(Role.TOWNSPERSON, 1, this.players.size);
-
+  assignRoles(roles: Array<Role>) {
     // Shuffle the array and assign a role to each person.
     shuffleArray(roles);
     this.players.forEach((player, id) => (player.role = roles.pop()));


### PR DESCRIPTION
Allow setting roles from client-side
Implement voting logic for Mafia

The role filling part is tested and appears to work fine. The mafia voting is not tested as I was running into an unrelated issue. Since the logic is so similar to player voting, this may be a safe merge if you want to move forward with the multiple mafia logic right away. 